### PR TITLE
Use Redash default (and often lower) process count

### DIFF
--- a/render-redash.sh
+++ b/render-redash.sh
@@ -6,8 +6,4 @@ export PYTHONUNBUFFERED=1
 export REDASH_HOST="$RENDER_EXTERNAL_HOSTNAME"
 export REDASH_REDIS_URL="redis://${REDIS_HOSTPORT}/0"
 
-NCPUS="$(nproc)"
-export REDASH_WEB_WORKERS="${REDASH_WEB_WORKERS:-$NCPUS}"
-export WORKERS_COUNT="${WORKERS_COUNT:-$NCPUS}"
-
 exec /app/bin/docker-entrypoint "$@"


### PR DESCRIPTION
Prior to this commit, we were using the processor count to set the
number of processes in the web service. That was causing RAM and/or CPU
to be maxed out. This commit uses the Redash defaults which are defined
here https://github.com/getredash/redash/blob/46ea3b1f0b263ba310de7c2c17e4a32d3ea4c343/bin/docker-entrypoint#L35