### PR TITLE
Upgrade to Redash v10.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM redash/redash:latest
+# Most recent version released as of 2022-05-10
+FROM redash/redash:10.1.0.b50633
 
 COPY ./render-redash.sh /bin/render-redash
 ENTRYPOINT ["/bin/render-redash"]

--- a/README.md
+++ b/README.md
@@ -29,3 +29,26 @@ See the guide at https://render.com/docs/deploy-redash.
 If you need help, chat with us at https://render.com/chat.
 
 [Redash]: https://redash.io
+
+## Upgrade
+
+### From v8 to v10
+
+*Note that Redash v10 requires more resources:*
+
+- The Web Service now uses the **Standard Plus** plan instead of the **Standard** plan because it needs more RAM.
+- An additional **Background Worker** service, `redash-default-worker`, is deployed bringing the total Background Worker count up to three.
+
+Please see https://render.com/pricing to determine how these changes will affect your Render charges.
+
+**Steps to upgrade:**
+
+1. Make sure you have performed a backup of your existing Redash database. You can [manually trigger a database backup](https://render.com/docs/databases#backups) from the Render Dashboard.
+2. Review the **Redash Dashboard URL Changes** section in the [v10.0.0 release notes](https://github.com/getredash/redash/releases/tag/v10.0.0). Note that you do *not* need to follow the **How to Upgrade** steps. Those are specific to deploying Redash with Docker Compose. The updates we've made to this repository have taken care of those steps for you.
+3. Review the **Impact** section at [this link](https://github.com/getredash/redash/security/advisories/GHSA-g8xr-f424-h2rv) discussing the security vulnerabilities fixed in v10.1.0 to understand if they affect your previous deploy.
+4. Go to **Render Dashboard** --> **Blueprints** --> your existing Redash Blueprint, and then click **Manual Sync**. This will deploy a v10 version of Redash for the Web Service and your Background Workers.
+5. Run database migrations required for v10 from the **Shell** of your Web Service: `render-redash manage db upgrade`.
+6. Clean-up resources that are no longer needed:
+   1. Delete the `QUEUES`, `WORKERS_COUNT`, and `REDIS_HOSTPORT` environment variables in the `redash-scheduler` service.
+   2. Delete the `REDIS_HOSTPORT` environment variable in the `redash-worker` service.
+   3. Delete the `redash-redis` **Private Service**. Ensure you do not delete the newly created **Managed Redis** service. You can differentiate between the two using the **Type** column in the Dashboard.

--- a/render-redash.sh
+++ b/render-redash.sh
@@ -4,6 +4,5 @@ set -e
 export PYTHONUNBUFFERED=1
 
 export REDASH_HOST="$RENDER_EXTERNAL_HOSTNAME"
-export REDASH_REDIS_URL="redis://${REDIS_HOSTPORT}/0"
 
 exec /app/bin/docker-entrypoint "$@"

--- a/render.yaml
+++ b/render.yaml
@@ -5,21 +5,25 @@ databases:
 
 services:
   # Do not forget to run `render-redash create_db` in Render Shell after creating this service.
+  # If you have upgraded from a previous version, run `render-redash manage db upgrade` instead.
   - type: web
     name: redash
     env: docker
-    plan: standard
+    plan: standard plus
     dockerCommand: render-redash server
+    healthCheckPath: /ping
     envVars:
+      - key: PORT
+        value: 5000
       - key: REDASH_DATABASE_URL
         fromDatabase:
           name: redash
           property: connectionString
-      - key: REDIS_HOSTPORT
+      - key: REDASH_REDIS_URL
         fromService:
-          type: pserv
+          type: redis
           name: redash-redis
-          property: hostport
+          property: connectionString
       - fromGroup: redash-shared
       - fromGroup: redash-mail
 
@@ -32,17 +36,13 @@ services:
         fromDatabase:
           name: redash
           property: connectionString
-      - key: REDIS_HOSTPORT
+      - key: REDASH_REDIS_URL
         fromService:
-          type: pserv
+          type: redis
           name: redash-redis
-          property: hostport
+          property: connectionString
       - fromGroup: redash-shared
       - fromGroup: redash-mail
-      - key: QUEUES
-        value: "celery"
-      - key: WORKERS_COUNT
-        value: 1
 
   - type: worker
     name: redash-worker
@@ -54,24 +54,43 @@ services:
         fromDatabase:
           name: redash
           property: connectionString
-      - key: REDIS_HOSTPORT
+      - key: REDASH_REDIS_URL
         fromService:
-          type: pserv
+          type: redis
           name: redash-redis
-          property: hostport
+          property: connectionString
       - fromGroup: redash-shared
       - fromGroup: redash-mail
       - key: QUEUES
         value: "queries,scheduled_queries,schemas"
+      - key: WORKERS_COUNT
+        value: 2
 
-  - type: pserv
-    name: redash-redis
+  - type: worker
+    name: redash-default-worker
     env: docker
-    repo: https://github.com/render-examples/redis.git
-    disk:
-      name: data
-      mountPath: /var/lib/redis
-      sizeGB: 10
+    plan: standard
+    dockerCommand: render-redash worker
+    envVars:
+      - key: REDASH_DATABASE_URL
+        fromDatabase:
+          name: redash
+          property: connectionString
+      - key: REDASH_REDIS_URL
+        fromService:
+          type: redis
+          name: redash-redis
+          property: connectionString
+      - fromGroup: redash-shared
+      - fromGroup: redash-mail
+      - key: QUEUES
+        value: "periodic emails default"
+      - key: WORKERS_COUNT
+        value: 1
+
+  - type: redis
+    name: redash-redis
+    ipAllowList: []
 
 envVarGroups:
   - name: redash-shared


### PR DESCRIPTION
Notes:
- Redash v10 requires a higher plan with more RAM
- Redash v10 also adds another Background Worker service
- Use Render's managed Redis instead of a Docker image

To test an upgrade from v8 to v10 using this PR branch, you must follow a modified version of the [Upgrade steps in the README](https://github.com/render-examples/redash/tree/crc/v10#upgrade). Instead of step 4, please do the following:

1. For the `redash` Web Service, `redash-scheduler` Background Worker, and `redash-worker` Background Worker, go to **Settings** and change the **Branch** to this one: `crc/v10`.
2. Create a new **Background Worker** using this repository and the `crc/v10` branch. Name it `redash-default-worker`, and give it the following additional settings
    - An **Environment Variable** named `QUEUES` with value `periodic emails default`
    - An **Environment Variable** named `WORKERS_COUNT` with value `1`
    - An **Environment Variable** named `REDASH_DATABASE_URL` with value set to the internal connection string of your Redash PostgreSQL database
    - An **Environment Variable** named `REDASH_REDIS_URL` with the value set to the internal connection string of your Redash Redis instance.
    - **Docker Command** set to `render-redash worker`
3. Lastly, click **Create Background Worker**, then go to the **Environment** section of the newley created Background Worker (you can do this before it is finished deploying), and link the `redash-shared` Environment Group to this service.