### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,7 @@ services:
     env: docker
     plan: standard
     dockerCommand: render-redash server
+    autoDeploy: false
     envVars:
       - key: REDASH_DATABASE_URL
         fromDatabase:
@@ -27,6 +28,7 @@ services:
     name: redash-scheduler
     env: docker
     dockerCommand: render-redash scheduler
+    autoDeploy: false
     envVars:
       - key: REDASH_DATABASE_URL
         fromDatabase:
@@ -49,6 +51,7 @@ services:
     env: docker
     plan: standard
     dockerCommand: render-redash worker
+    autoDeploy: false
     envVars:
       - key: REDASH_DATABASE_URL
         fromDatabase:
@@ -68,6 +71,7 @@ services:
     name: redash-redis
     env: docker
     repo: https://github.com/render-examples/redis.git
+    autoDeploy: false
     disk:
       name: data
       mountPath: /var/lib/redis


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See [the Render docs](https://render.com/docs/deploy-to-render) for more information.

Signed-off-by: zach wick <zach@render.com>